### PR TITLE
Add empty response error message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "source": "https://github.com/shevabam/recaptcha/tree/master"
     },
     "license": "GPL-2.0-only",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "require": {
         "php": ">=5.3.0"
     },

--- a/src/reCAPTCHA.php
+++ b/src/reCAPTCHA.php
@@ -4,7 +4,7 @@ namespace Phelium\Component;
 
 /**
  * reCAPTCHA v2 class
- * 
+ *
  * @author ShevAbam
  * @link https://github.com/shevabam/recaptcha
  * @license GNU GPL 2.0
@@ -13,35 +13,35 @@ class reCAPTCHA
 {
     /**
      * ReCAPTCHA URL verifying
-     * 
+     *
      * @var string
      */
     const VERIFY_URL = 'https://www.google.com/recaptcha/api/siteverify';
 
     /**
      * Public key
-     * 
+     *
      * @var string
      */
     private $siteKey;
 
     /**
      * Private key
-     * 
+     *
      * @var string
      */
     private $secretKey;
 
     /**
      * Remote IP address
-     * 
+     *
      * @var string
      */
     protected $remoteIp = null;
 
     /**
      * Supported themes
-     * 
+     *
      * @var array
      * @see https://developers.google.com/recaptcha/docs/display#config
      */
@@ -49,7 +49,7 @@ class reCAPTCHA
 
     /**
      * Captcha theme. Default : light
-     * 
+     *
      * @var string
      * @see https://developers.google.com/recaptcha/docs/display#config
      */
@@ -57,7 +57,7 @@ class reCAPTCHA
 
     /**
      * Supported types
-     * 
+     *
      * @var array
      * @see https://developers.google.com/recaptcha/docs/display#config
      */
@@ -65,7 +65,7 @@ class reCAPTCHA
 
     /**
      * Captcha type. Default : image
-     * 
+     *
      * @var string
      * @see https://developers.google.com/recaptcha/docs/display#config
      */
@@ -73,22 +73,22 @@ class reCAPTCHA
 
     /**
      * Captcha language. Default : auto-detect
-     * 
+     *
      * @var string
      * @see https://developers.google.com/recaptcha/docs/language
      */
     protected $language = null;
 
-    /**  
+    /**
      * CURL timeout (in seconds) to verify response
      *
      * @var int
      */
     private $verifyTimeout = 1;
-  
+
     /**
      * Captcha size. Default : normal
-     * 
+     *
      * @var string
      * @see https://developers.google.com/recaptcha/docs/display#render_param
      */
@@ -96,7 +96,7 @@ class reCAPTCHA
 
     /**
      * List of errors
-     * 
+     *
      * @var array
      */
     protected $errorCodes = array();
@@ -104,7 +104,7 @@ class reCAPTCHA
 
     /**
      * Initialize site and secret keys
-     * 
+     *
      * @param string $siteKey Site key from ReCaptcha dashboard
      * @param string $secretKey Secret key from ReCaptcha dashboard
      * @return void
@@ -117,7 +117,7 @@ class reCAPTCHA
 
     /**
      * Set site key
-     * 
+     *
      * @param string $key
      * @return object
      */
@@ -130,7 +130,7 @@ class reCAPTCHA
 
     /**
      * Set secret key
-     * 
+     *
      * @param string $key
      * @return object
      */
@@ -143,7 +143,7 @@ class reCAPTCHA
 
     /**
      * Set remote IP address
-     * 
+     *
      * @param string $ip
      * @return object
      */
@@ -209,10 +209,10 @@ class reCAPTCHA
     public function setVerifyTimeout($timeout)
     {
         $this->verifyTimeout = $timeout;
-      
+
         return $this;
     }
-  
+
     /**
      * Set size
      *
@@ -228,7 +228,7 @@ class reCAPTCHA
 
     /**
      * Generate the JS code of the captcha
-     * 
+     *
      * @return string
      */
     public function getScript()
@@ -242,7 +242,7 @@ class reCAPTCHA
 
     /**
      * Generate the HTML code block for the captcha
-     * 
+     *
      * @return string
      */
     public function getHtml()
@@ -266,7 +266,7 @@ class reCAPTCHA
 
     /**
      * Checks the code given by the captcha
-     * 
+     *
      * @param string $response Response code after submitting form (usually $_POST['g-recaptcha-response'])
      * @return bool
      */
@@ -279,13 +279,13 @@ class reCAPTCHA
             return false;
 
         $params = array(
-            'secret'    => $this->secretKey,
-            'response'  => $response,
-            'remoteip'  => $this->remoteIp,
+            'secret'   => $this->secretKey,
+            'response' => $response,
+            'remoteip' => $this->remoteIp,
         );
 
         $url = self::VERIFY_URL.'?'.http_build_query($params);
-        
+
         if (function_exists('curl_version'))
         {
             $curl = curl_init($url);
@@ -299,12 +299,12 @@ class reCAPTCHA
         {
             $response = file_get_contents($url);
         }
-    
+
         if (empty($response) || is_null($response) || !$response)
         {
             return false;
         }
-    
+
         $json = json_decode($response, true);
 
         if (isset($json['error-codes']))
@@ -317,7 +317,7 @@ class reCAPTCHA
 
     /**
      * Returns the errors encountered
-     * 
+     *
      * @return array Errors code and name
      */
     public function getErrorCodes()
@@ -336,28 +336,28 @@ class reCAPTCHA
                             'name' => 'Timeout or duplicate.',
                         );
                     break;
-                    
+
                     case 'missing-input-secret':
                         $errors[] = array(
                             'code' => $error,
                             'name' => 'The secret parameter is missing.',
                         );
                     break;
-                    
+
                     case 'invalid-input-secret':
                         $errors[] = array(
                             'code' => $error,
                             'name' => 'The secret parameter is invalid or malformed.',
                         );
                     break;
-                    
+
                     case 'missing-input-response':
                         $errors[] = array(
                             'code' => $error,
                             'name' => 'The response parameter is missing.',
                         );
                     break;
-                    
+
                     case 'invalid-input-response':
                         $errors[] = array(
                             'code' => $error,

--- a/src/reCAPTCHA.php
+++ b/src/reCAPTCHA.php
@@ -274,9 +274,13 @@ class reCAPTCHA
     {
         if (is_null($this->secretKey))
             throw new \Exception('You must set your secret key');
-           
-        if (empty($response))
+
+        if (empty($response)) {
+
+            $this->errorCodes = ['internal-empty-response'];
+
             return false;
+        }
 
         $params = array(
             'secret'   => $this->secretKey,
@@ -369,6 +373,13 @@ class reCAPTCHA
                         $errors[] = array(
                             'code' => $error,
                             'name' => 'The request is invalid or malformed.',
+                        );
+                    break;
+
+                    case 'internal-empty-response':
+                        $errors[] = array(
+                            'code' => $error,
+                            'name' => 'The recaptcha response is required.',
                         );
                     break;
 

--- a/src/reCAPTCHA.php
+++ b/src/reCAPTCHA.php
@@ -277,7 +277,7 @@ class reCAPTCHA
 
         if (empty($response)) {
 
-            $this->errorCodes = ['internal-empty-response'];
+            $this->errorCodes = array('internal-empty-response');
 
             return false;
         }


### PR DESCRIPTION
To allow the error message handling to stay internal to the library and following the reCAPTCHA API response error format, add a error handler for an empty response instead of just returning false out of the validation.

This helps to keep error message generation on implementation easy without having to perform additional checks for empty post :)